### PR TITLE
Alternate Connect method

### DIFF
--- a/Windows.Devices.WiFi/WiFiAvailableNetwork.cs
+++ b/Windows.Devices.WiFi/WiFiAvailableNetwork.cs
@@ -21,13 +21,13 @@ namespace Windows.Devices.WiFi
         /// <summary>
         /// Gets the MAC address of the access point.
         /// </summary>
-        public string Bsid { get { return _bsid; } internal set { _bsid = value; } }
+        public string Bsid { get { return _bsid; } set { _bsid = value; } }
 
 
         /// <summary>
         /// Gets the SSID (name) of the network.
         /// </summary>
-        public string Ssid { get { return _ssid; } internal set { _ssid = value; } }
+        public string Ssid { get { return _ssid; } set { _ssid = value; } }
 
         /// <summary>
         /// Gets a value describing the kind of network being described.


### PR DESCRIPTION
## Description
Changes made to the AvailableNetwork class.
Initialization of Ssid and Bsid properties - removed 'internal'.
These properties now conform to the .NET standard.


## Motivation and Context
.NET allows the Ssid and Bsid properties to be initialized by the user application.
The nanoFramework implementation now allows this as well.


## How Has This Been Tested?
Created a nanoFramework project that sets initializes the Ssid and Bsid properties.



## Types of changes

- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
