### PR TITLE
Alternate connect method

### DIFF
--- a/Windows.Devices.WiFi/WiFiAdapter.cs
+++ b/Windows.Devices.WiFi/WiFiAdapter.cs
@@ -133,6 +133,22 @@ namespace Windows.Devices.WiFi
             }
         }
 
+        /// <summary>
+        /// Connect this Wi-Fi device to the specified network, with the specified passphrase and reconnection policy.
+        /// </summary>
+        /// <param name="ssid">Describes the Wi-Fi network to be connected.</param>
+        /// <param name="reconnectionKind">Specifies how to reconnect if the connection is lost.</param>
+        /// <param name="passwordCredential">The passphrase to be used to connect to the access point.</param>
+        /// <returns>
+        /// On successful conclusion of the operation, returns an object that describes the result of the connect operation.
+        /// </returns>
+        public WiFiConnectionResult Connect(string ssid, WiFiReconnectionKind reconnectionKind, string passwordCredential)
+        {
+            WiFiAvailableNetwork availableNetwork = new WiFiAvailableNetwork();
+            availableNetwork.Ssid = ssid;
+            return Connect(availableNetwork, reconnectionKind, passwordCredential);
+        }
+
 
         /// <summary>
         /// Disconnects any active Wi-Fi connection through this adapter.

--- a/Windows.Devices.WiFi/WiFiAdapter.cs
+++ b/Windows.Devices.WiFi/WiFiAdapter.cs
@@ -134,7 +134,7 @@ namespace Windows.Devices.WiFi
         }
 
         /// <summary>
-        /// Connect this Wi-Fi device to the specified network, with the specified passphrase and reconnection policy.
+        /// Connect this Wi-Fi device to the specified network (using SSID string), with the specified passphrase and reconnection policy.
         /// </summary>
         /// <param name="ssid">Describes the Wi-Fi network to be connected.</param>
         /// <param name="reconnectionKind">Specifies how to reconnect if the connection is lost.</param>

--- a/Windows.Devices.WiFi/Windows.Devices.Wifi.nfproj
+++ b/Windows.Devices.WiFi/Windows.Devices.Wifi.nfproj
@@ -64,12 +64,12 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib, Version=1.10.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.3-preview.7\lib\mscorlib.dll</HintPath>
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.3-preview.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.Runtime.Events.1.9.0-preview.16\lib\nanoFramework.Runtime.Events.dll</HintPath>
+      <HintPath>packages\nanoFramework.Runtime.Events.1.9.0-preview.16\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/Windows.Devices.WiFi/Windows.Devices.Wifi.nfproj
+++ b/Windows.Devices.WiFi/Windows.Devices.Wifi.nfproj
@@ -66,10 +66,12 @@
     <Reference Include="mscorlib, Version=1.10.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.3-preview.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\packages\nanoFramework.Runtime.Events.1.9.0-preview.16\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
   </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />

--- a/Windows.Devices.WiFi/Windows.Devices.Wifi.sln
+++ b/Windows.Devices.WiFi/Windows.Devices.Wifi.sln
@@ -22,6 +22,6 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {3F425CDD-7149-45C1-A610-16C43682F2D9}
+		SolutionGuid = {DB8D59C2-6070-4C0D-8E29-63BD2454C1DF}
 	EndGlobalSection
 EndGlobal

--- a/Windows.Devices.WiFi/Windows.Devices.Wifi.sln
+++ b/Windows.Devices.WiFi/Windows.Devices.Wifi.sln
@@ -1,17 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2027
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31129.286
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{11A8DD76-328B-46DF-9F39-F559912D0360}") = "Windows.Devices.Wifi", "Windows.Devices.Wifi\Windows.Devices.Wifi.nfproj", "{A42BC265-9F96-48E2-AA2A-A5119B9B0B79}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{19A726FD-5E93-45A7-AD59-A79EFE734567}"
-	ProjectSection(SolutionItems) = preProject
-		nanoFramework.Windows.Devices.Wifi.DELIVERABLES.nuspec = nanoFramework.Windows.Devices.Wifi.DELIVERABLES.nuspec
-		nanoFramework.Windows.Devices.Wifi.nuspec = nanoFramework.Windows.Devices.Wifi.nuspec
-		NuGet.Config = NuGet.Config
-		version.json = version.json
-	EndProjectSection
+Project("{11A8DD76-328B-46DF-9F39-F559912D0360}") = "Windows.Devices.Wifi", "Windows.Devices.Wifi.nfproj", "{A42BC265-9F96-48E2-AA2A-A5119B9B0B79}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,13 +13,15 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A42BC265-9F96-48E2-AA2A-A5119B9B0B79}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A42BC265-9F96-48E2-AA2A-A5119B9B0B79}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A42BC265-9F96-48E2-AA2A-A5119B9B0B79}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
 		{A42BC265-9F96-48E2-AA2A-A5119B9B0B79}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A42BC265-9F96-48E2-AA2A-A5119B9B0B79}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A42BC265-9F96-48E2-AA2A-A5119B9B0B79}.Release|Any CPU.Deploy.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {5B25FB16-AF7D-469F-81C8-EBC91AA28FAE}
+		SolutionGuid = {3F425CDD-7149-45C1-A610-16C43682F2D9}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Alternate Connect() method added to WiFiAdapter.cs

## Description
An alternate Connect() method has been added which allows the user to specify an SSID string value.

## Motivation and Context
This modification allows for immediate connection to a known SSID without having to scan for all wifi networks and wait for the desired SSID to respond to ScanAsync().

## Testing
Was not able to test this change in a local environment.  Apparently, the WiFi lib needs to be updated to work with the current nanoFramework CLR. 

## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
